### PR TITLE
`domain_groupby` kwarg

### DIFF
--- a/scnym/api.py
+++ b/scnym/api.py
@@ -126,6 +126,7 @@ def scnym_api(
     adata: AnnData,
     task: str='train',
     groupby: str=None,
+    domain_groupby: str=None,
     out_path: str='./scnym_outputs',
     trained_model: str=None,
     config: Union[dict, str]='new_identity_discovery',
@@ -157,6 +158,12 @@ def scnym_api(
         Column in `adata.obs` that contains cell identity annotations.
         Values of `"Unlabeled"` indicate that a given cell should be used
         only as unlabeled data during training.
+    domain_groupby
+        Column in `adata.obs` that contains domain labels as integers.
+        Each domain of origin (e.g. batch, species) should be given a unique
+        domain label.
+        If `domain_groupby is None`, train and target data are each considered
+        a unique domain.
     out_path
         Path to a directory for saving scNym model weights and training logs.
     trained_model
@@ -276,6 +283,7 @@ def scnym_api(
     config['groupby']   = groupby
     config['key_added'] = key_added
     config['trained_model'] = trained_model
+    config['domain_groupby'] = domain_groupby
     
     ################################################
     # check that there are no duplicate genes in the input object

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -342,11 +342,12 @@ def test_user_domains():
     print('val   samples = ', np.sum(adata.obs['scNym_split']=='val'))
     
     # train an scNym model
-    config = {'n_epochs': 1, 'domain_groupby': domain_groupby}
+    config = {'n_epochs': 1,}
     scnym_api(
         adata=adata,
         task='train',
         groupby='cell',
+        domain_groupby=domain_groupby,
         out_path=str(sc.settings.datasetdir),
         config=config,
     )


### PR DESCRIPTION
This PR adds an `scnym_api(...)` keyword argument `domain_groupby`. Previously, this argument was listed in the tutorial but only accessible by manually editing the config file.