### PR TITLE
change available human atlases to match those in cell_atlas.json

### DIFF
--- a/scnym/api.py
+++ b/scnym/api.py
@@ -54,7 +54,8 @@ WEIGHTS_JSON = "https://storage.googleapis.com/calico-website-scnym-storage/link
 REFERENCE_JSON = "https://storage.googleapis.com/calico-website-scnym-storage/link_tables/cell_atlas.json"
 
 ATLAS_ANNOT_KEYS = {
-    "human": "celltype",
+    "human_gtex": "cell_type",
+    "human_gtex_immune": "cell_type",
     "mouse": "cell_ontology_class",
     "rat": "cell_ontology_class",
 }
@@ -822,6 +823,11 @@ def atlas2target(
         names for the relevant species to match the atlas.
         e.g. `"Gapdh`" for mouse or `"GAPDH"` for human, rather
         than Ensembl gene IDs or another gene annotation.
+    species : str
+        One of "human_gtex", "human_gtex_immune", "mouse",
+        or "rat".
+    key_added: str
+        Name to use for the column where cell labels are added
 
     Returns
     -------


### PR DESCRIPTION
### Description of your changes
The species listed in `scnym.apy.ATLAS_ANNOT_KEYS` does not match those listed in the cell_atlas.json.  Specifically, there is no "human" key, just "human_gtex" and "human_gtex_immune".  This causes other functions, such as `atlas2target()` to fail.

### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation add / update

### (If applicable) How has this been tested?
Made changes, installed package, successfully used `scnym.api.atlas2target()`
